### PR TITLE
Add env example and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://user:pass@localhost:5432/corefoundry
+NEXTAUTH_SECRET=una_cadena_segura
+GOOGLE_CLIENT_ID=tu_id_google
+GOOGLE_CLIENT_SECRET=tu_secreto_google

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ GOOGLE_CLIENT_SECRET=tu_secreto_google
 ```
 
 Añade cualquier otra variable que requiera tu configuración específica.
+Si planeas usar `docker-compose`, define además `POSTGRES_USER`,
+`POSTGRES_PASSWORD` y `POSTGRES_DB` en un archivo `.env`.
 
 ---
 
@@ -147,16 +149,20 @@ Para más detalles, consulta la carpeta `./docs/api`.
 
 ### Docker
 
-1. Construye la imagen:
+1. Crea un archivo `.env` si vas a usar Docker Compose:
+   ```bash
+   cp .env.example .env
+   ```
+2. Construye la imagen:
    ```bash
    docker build -t corefoundry:latest .
    ```
-2. Etiqueta y sube a tu registry:
+3. Etiqueta y sube a tu registry:
    ```bash
    docker tag corefoundry:latest tu-registry/corefoundry:latest
    docker push tu-registry/corefoundry:latest
    ```
-3. Ejecuta con Docker Compose:
+4. Ejecuta con Docker Compose:
    ```bash
    docker-compose up -d
    ```


### PR DESCRIPTION
## Summary
- add `.env.example` placeholder with required values
- allow committing example env file in `.gitignore`
- document docker compose env setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68746f4f2b7c83338ac31f2e833089d8