### PR TITLE
Centralize ModuleConfig type

### DIFF
--- a/src/core/ModuleLoader.ts
+++ b/src/core/ModuleLoader.ts
@@ -1,7 +1,7 @@
 import { inventoryModuleConfig } from '@/modules/inventory/config';
 import { crmModuleConfig }       from '@/modules/crm/config';
 import { logisticsModuleConfig } from '@/modules/logistics/config';
-import type { ModuleConfig } from '@/modules/inventory/config';
+import type { ModuleConfig } from '@/modules/module-types';
 
 // Usamos la interfaz ModuleConfig importada para asegurar consistencia entre módulos.
 

--- a/src/modules/crm/config.ts
+++ b/src/modules/crm/config.ts
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic';
-import type { ModuleConfig } from '@/modules/inventory/config';
+import type { ModuleConfig } from '@/modules/module-types';
 
 export const crmModuleConfig: ModuleConfig = {
     id: 'crm',

--- a/src/modules/inventory/config.ts
+++ b/src/modules/inventory/config.ts
@@ -1,14 +1,5 @@
 import dynamic from 'next/dynamic';
-import type { ComponentType } from 'react';
-
-export interface ModuleConfig {
-    id: string;
-    name: string;
-    dependencies: string[];
-    apiBasePath: string;
-    // Componente de interfaz de usuario con props desconocidos.
-    UiComponent: ComponentType<unknown>;
-}
+import type { ModuleConfig } from '@/modules/module-types';
 
 export const inventoryModuleConfig: ModuleConfig = {
     id: 'inventory',

--- a/src/modules/logistics/config.ts
+++ b/src/modules/logistics/config.ts
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic';
-import type { ModuleConfig } from '@/modules/inventory/config';
+import type { ModuleConfig } from '@/modules/module-types';
 
 export const logisticsModuleConfig: ModuleConfig = {
     id: 'logistics',

--- a/src/modules/module-types.ts
+++ b/src/modules/module-types.ts
@@ -1,0 +1,9 @@
+import type { ComponentType } from 'react';
+
+export interface ModuleConfig {
+    id: string;
+    name: string;
+    dependencies: string[];
+    apiBasePath: string;
+    UiComponent: ComponentType<unknown>;
+}


### PR DESCRIPTION
## Summary
- create shared `ModuleConfig` interface
- update inventory, CRM and logistics modules to import from shared file
- adjust `ModuleLoader` to use new interface path

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687476028d0483339f2a4acc428a10fe