### PR TITLE
Add API routes for inventory and logistics

### DIFF
--- a/src/app/api/modules/inventory/route.ts
+++ b/src/app/api/modules/inventory/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const inventoryData = [
+    { id: 'item-001', name: 'Tornillos de Acero', quantity: 15000 },
+    { id: 'item-002', name: 'Placas de Cobre', quantity: 7500 },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function GET(_req: NextRequest) {
+    try {
+        return NextResponse.json(inventoryData);
+    } catch (error) {
+        console.error('[Inventory API] GET Error:', error);
+        return NextResponse.json({ error: 'Error interno del servidor' }, { status: 500 });
+    }
+}

--- a/src/app/api/modules/logistics/route.ts
+++ b/src/app/api/modules/logistics/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+const mockShipments = [
+    { id: 'shp-001', from: 'inventory', to: 'cust-01', status: 'En tránsito' },
+];
+
+export async function GET() {
+    return NextResponse.json(mockShipments);
+}


### PR DESCRIPTION
## Summary
- expose Inventory API under `/api/modules/inventory`
- expose Logistics API under `/api/modules/logistics`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874877542648333b5fd574a105d6e35