### PR TITLE
Enable Sentry client auto-load

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Si planeas usar `docker-compose`, define además `POSTGRES_USER`,
 - **Endpoint de salud**: `/api/health`.
 - **Logs**: estructurados con Pino.
 - **Trazas**: integradas con OpenTelemetry.
+- **Sentry en el cliente**: Next.js carga automáticamente `instrumentation.client.ts` para inicializar Sentry en el navegador.
 
 ---
 

--- a/instrumentation.client.ts
+++ b/instrumentation.client.ts
@@ -1,4 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
+// Next.js carga automáticamente este archivo al estar nombrado
+// `instrumentation.client.ts`, permitiendo inicializar Sentry en el navegador.
 
 /**
  * Este archivo se ejecuta solo en el navegador y es el lugar


### PR DESCRIPTION
## Summary
- rename `instrumentation-client.ts` to `instrumentation.client.ts`
- document automatic loading in README
- add explanation comment in `instrumentation.client.ts`

## Testing
- `npm run lint`
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6874877ec7408333adfbdcaa556ae4c3