### PR TITLE
Integrate basic Stripe webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ NEXTAUTH_URL=http://localhost:3001
 NEXTAUTH_SALT=una_cadena_segura_para_salt
 GOOGLE_CLIENT_ID=tu_id_google
 GOOGLE_CLIENT_SECRET=tu_secreto_google
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Antes de comenzar, asegúrate de tener:
     - `NEXTAUTH_URL`
     - `NEXTAUTH_SALT`
     - `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET`
+    - `STRIPE_SECRET_KEY` y `STRIPE_WEBHOOK_SECRET`
 
 ---
 
@@ -99,6 +100,8 @@ NEXTAUTH_URL=http://localhost:3001
 NEXTAUTH_SALT=una_cadena_segura_para_salt
 GOOGLE_CLIENT_ID=tu_id_google
 GOOGLE_CLIENT_SECRET=tu_secreto_google
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
 ```
 
 Añade cualquier otra variable que requiera tu configuración específica.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prom-client": "^15.1.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "stripe": "^14.0.0",
     "zustand": "^4.5.4"
   },
   "devDependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Tenant {
   visualConfig  Json
   userId        String   @unique
   user          User     @relation(fields: [userId], references: [id])
+  subscription  Subscription?
 }
 
 model CrmContact {
@@ -74,4 +75,14 @@ model CrmContact {
   company String
   userId  String
   user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Subscription {
+  id             String  @id @default(cuid())
+  tenantId       String  @unique
+  tenant         Tenant  @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  customerId     String
+  subscriptionId String
+  plan           String
+  status         String
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { db } from '@/lib/db';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2024-04-10',
+});
+
+export async function POST(req: NextRequest) {
+  const body = await req.text();
+  const signature = req.headers.get('stripe-signature');
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
+
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(body, signature!, webhookSecret);
+  } catch (err) {
+    console.error('[Stripe Webhook] Signature verification failed.', err);
+    return new NextResponse('Webhook Error', { status: 400 });
+  }
+
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      if (!session.customer || !session.subscription || !session.metadata?.tenantId) break;
+
+      await db.subscription.upsert({
+        where: { tenantId: session.metadata.tenantId },
+        update: {
+          customerId: session.customer.toString(),
+          subscriptionId: session.subscription.toString(),
+          status: 'active',
+        },
+        create: {
+          tenantId: session.metadata.tenantId,
+          customerId: session.customer.toString(),
+          subscriptionId: session.subscription.toString(),
+          plan: session.metadata.plan ?? 'basic',
+          status: 'active',
+        },
+      });
+      break;
+    }
+    case 'customer.subscription.updated': {
+      const sub = event.data.object as Stripe.Subscription;
+      if (typeof sub.metadata?.tenantId !== 'string') break;
+
+      await db.subscription.update({
+        where: { tenantId: sub.metadata.tenantId },
+        data: {
+          status: sub.status,
+          plan: sub.items.data[0]?.price.nickname ?? 'basic',
+        },
+      });
+      break;
+    }
+    default:
+      console.log(`[Stripe Webhook] Unhandled event type ${event.type}`);
+  }
+
+  return NextResponse.json({ received: true });
+}


### PR DESCRIPTION
## Summary
- add Stripe dependency
- store Stripe config in env
- update Prisma schema with Subscription model
- document Stripe variables in README
- handle Stripe webhook events via API route

## Testing
- `npm test --silent`
- `npm run lint --silent`
- `npm run build --silent` *(fails: Module not found 'stripe', due to network install issue)*

------
https://chatgpt.com/codex/tasks/task_e_687512413fac83338493f86d9a6e0dff