### PR TITLE
Add tenant collaboration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,8 @@ model User {
   image         String?
   accounts      Account[]
   sessions      Session[]
-  tenant        Tenant?
+  ownedTenant   Tenant?      @relation("TenantOwner")
+  memberships   TenantUser[]
   crmContacts   CrmContact[]
 }
 
@@ -63,9 +64,11 @@ model Tenant {
   name          String
   activeModules String[]
   visualConfig  Json
-  userId        String   @unique
-  user          User     @relation(fields: [userId], references: [id])
+  ownerId       String   @unique
+  owner         User     @relation("TenantOwner", fields: [ownerId], references: [id])
   subscription  Subscription?
+  memberships   TenantUser[]
+  invitations   Invitation[]
 }
 
 model CrmContact {
@@ -85,4 +88,34 @@ model Subscription {
   subscriptionId String
   plan           String
   status         String
+}
+
+model TenantUser {
+  tenantId String
+  userId   String
+  role     TenantRole
+
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([tenantId, userId])
+}
+
+model Invitation {
+  id       String     @id @default(cuid())
+  tenantId String
+  email    String
+  role     TenantRole
+  accepted Boolean    @default(false)
+
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@unique([tenantId, email])
+}
+
+enum TenantRole {
+  OWNER
+  ADMIN
+  EDITOR
+  VIEWER
 }

--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function SettingsPage() {
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/tenant/me')
+      .then(res => res.json())
+      .then(data => { setName(data.name); setLoading(false); });
+  }, []);
+
+  const handleSave = async () => {
+    await fetch('/api/tenant/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+  };
+
+  if (loading) return <p>Cargando...</p>;
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="text-2xl mb-4">Ajustes del Tenant</h1>
+      <label className="block mb-2">Nombre</label>
+      <input value={name} onChange={e => setName(e.target.value)} className="text-black mb-4" />
+      <button onClick={handleSave} className="bg-blue-600 px-4 py-2 rounded">Guardar</button>
+    </div>
+  );
+}

--- a/src/app/api/tenant/invite/route.ts
+++ b/src/app/api/tenant/invite/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { db } from '@/lib/db';
+
+const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET!;
+
+export async function GET(request: NextRequest) {
+    const token = await getToken({ req: request, secret: NEXTAUTH_SECRET });
+    if (!token?.sub) return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+
+    const invites = await db.invitation.findMany({
+        where: { tenant: { ownerId: token.sub } }
+    });
+    return NextResponse.json(invites);
+}
+
+export async function POST(request: NextRequest) {
+    const token = await getToken({ req: request, secret: NEXTAUTH_SECRET });
+    if (!token?.sub) return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+
+    const { email, role } = await request.json();
+    const tenant = await db.tenant.findUnique({ where: { ownerId: token.sub } });
+    if (!tenant) return NextResponse.json({ error: 'Tenant no encontrado' }, { status: 404 });
+
+    const invitation = await db.invitation.create({
+        data: { tenantId: tenant.id, email, role }
+    });
+    return NextResponse.json(invitation, { status: 201 });
+}

--- a/src/app/api/tenant/settings/route.ts
+++ b/src/app/api/tenant/settings/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { db } from '@/lib/db';
+
+const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET!;
+
+export async function POST(request: NextRequest) {
+  const token = await getToken({ req: request, secret: NEXTAUTH_SECRET });
+  if (!token?.sub) return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+
+  const { name } = await request.json();
+  const tenant = await db.tenant.update({
+    where: { ownerId: token.sub },
+    data: { name }
+  });
+  return NextResponse.json(tenant);
+}

--- a/src/components/ui/ModulesSidebar.tsx
+++ b/src/components/ui/ModulesSidebar.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useMainStore } from '@/core/store/useMainStore';
 import { getAllModules } from '@/core/ModuleLoader';
 import { VisualConfig } from '@/lib/types';
+import Link from 'next/link';
 
 interface ModulesSidebarProps {
     onConfigChange: (newConfig: { activeModules: string[]; visualConfig: VisualConfig }) => Promise<void>;
@@ -63,6 +64,10 @@ export const ModulesSidebar = ({ onConfigChange }: ModulesSidebarProps) => {
                     );
                 })}
             </ul>
+            <hr className="my-4 border-gray-600" />
+            <Link href="/dashboard/settings" className="text-sm hover:underline">
+                Ajustes del Tenant
+            </Link>
             <style jsx>{`
                 .toggle-checkbox {
                     @apply transition-all duration-300 ease-in-out;

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -21,6 +21,22 @@ export interface Tenant {
     visualConfig: VisualConfig;
 }
 
+export type TenantRole = 'OWNER' | 'ADMIN' | 'EDITOR' | 'VIEWER';
+
+export interface TenantUser {
+    tenantId: string;
+    userId: string;
+    role: TenantRole;
+}
+
+export interface Invitation {
+    id: string;
+    tenantId: string;
+    email: string;
+    role: TenantRole;
+    accepted: boolean;
+}
+
 
 // --- Tipos para el Bus de Eventos ---
 // Define los tipos de eventos que pueden ocurrir en la aplicación.


### PR DESCRIPTION
## Summary
- expand Prisma schema for multi-user tenants
- add invitation endpoints for tenant collaboration
- link settings page from module sidebar
- let owners update tenant name

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875162773188333bab5b8d074500dd9