### PR TITLE
Add input validation, CSP header and new E2E test

### DIFF
--- a/cypress/e2e/module-flow.cy.ts
+++ b/cypress/e2e/module-flow.cy.ts
@@ -1,0 +1,17 @@
+describe('Flujo de activación y conexión de módulos', () => {
+  beforeEach(() => {
+    cy.visit('/dashboard');
+  });
+
+  it('activa un módulo y crea una conexión', () => {
+    cy.intercept('POST', '/api/tenant/me').as('updateTenant');
+
+    cy.contains('label', 'CRM').parent().find('input[type="checkbox"]').uncheck().check();
+    cy.wait('@updateTenant');
+
+    cy.get('#phaser-container canvas')
+      .click(150, 150, { shiftKey: true })
+      .click(200, 200, { shiftKey: true });
+    cy.wait('@updateTenant');
+  });
+});

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,22 @@ import { withSentryConfig } from "@sentry/nextjs";
 const nextConfig = {
     reactStrictMode: true,
 
+    async headers() {
+        const ContentSecurityPolicy =
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src https://accounts.google.com; connect-src 'self';";
+        return [
+            {
+                source: '/(.*)',
+                headers: [
+                    {
+                        key: 'Content-Security-Policy',
+                        value: ContentSecurityPolicy.replace(/\n/g, ''),
+                    },
+                ],
+            },
+        ];
+    },
+
     // Mantenemos la configuración de Webpack para evitar los errores de "Critical dependency"
     // que vimos con las librerías de instrumentación.
     webpack: (config, { isServer }) => {

--- a/src/app/api/modules/crm/route.ts
+++ b/src/app/api/modules/crm/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getToken }             from 'next-auth/jwt';
 import { db }                   from '@/lib/db';
 import { Prisma } from '@prisma/client';
+import { parseString } from '@/lib/validators';
 
 const SECRET = process.env.NEXTAUTH_SECRET!;
 const SALT = process.env.NEXTAUTH_SALT!;
@@ -26,9 +27,13 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
     }
 
-    const { name, email, company } = await request.json();
-    // Validaciones mínimas
-    if (!name || !email || !company) {
+    const body = await request.json().catch(() => ({}));
+    let name: string, email: string, company: string;
+    try {
+        name = parseString(body.name, 'name');
+        email = parseString(body.email, 'email');
+        company = parseString(body.company, 'company');
+    } catch {
         return NextResponse.json({ error: 'Campos incompletos' }, { status: 400 });
     }
 

--- a/src/app/api/tenant/invite/route.ts
+++ b/src/app/api/tenant/invite/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { db } from '@/lib/db';
+import { parseString } from '@/lib/validators';
 
 const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET!;
 
@@ -18,7 +19,14 @@ export async function POST(request: NextRequest) {
     const token = await getToken({ req: request, secret: NEXTAUTH_SECRET });
     if (!token?.sub) return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
 
-    const { email, role } = await request.json();
+    const body = await request.json().catch(() => ({}));
+    let email: string, role: string;
+    try {
+        email = parseString(body.email, 'email');
+        role = parseString(body.role, 'role');
+    } catch {
+        return NextResponse.json({ error: 'Datos inválidos' }, { status: 400 });
+    }
     const tenant = await db.tenant.findUnique({ where: { ownerId: token.sub } });
     if (!tenant) return NextResponse.json({ error: 'Tenant no encontrado' }, { status: 404 });
 

--- a/src/app/api/tenant/me/route.ts
+++ b/src/app/api/tenant/me/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getToken }             from 'next-auth/jwt';
 import { db }                   from '@/lib/db';
 import logger                   from '@/lib/logger';
+import { parseStringArray, parseVisualConfig } from '@/lib/validators';
 
 const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET!;
 
@@ -41,7 +42,9 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-        const { activeModules, visualConfig } = await request.json();
+        const body = await request.json().catch(() => ({}));
+        const activeModules = parseStringArray(body.activeModules, 'activeModules');
+        const visualConfig = parseVisualConfig(body.visualConfig);
         const tenant = await db.tenant.upsert({
             where: { ownerId: token.sub },
             update: {

--- a/src/app/api/tenant/settings/route.ts
+++ b/src/app/api/tenant/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { db } from '@/lib/db';
+import { parseString } from '@/lib/validators';
 
 const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET!;
 
@@ -8,7 +9,13 @@ export async function POST(request: NextRequest) {
   const token = await getToken({ req: request, secret: NEXTAUTH_SECRET });
   if (!token?.sub) return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
 
-  const { name } = await request.json();
+  const body = await request.json().catch(() => ({}));
+  let name: string;
+  try {
+    name = parseString(body.name, 'name');
+  } catch {
+    return NextResponse.json({ error: 'Datos inválidos' }, { status: 400 });
+  }
   const tenant = await db.tenant.update({
     where: { ownerId: token.sub },
     data: { name }

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,38 @@
+export function parseString(value: unknown, field: string): string {
+    if (typeof value !== 'string') throw new Error(`Invalid ${field}`);
+    const trimmed = value.trim();
+    if (!trimmed) throw new Error(`Invalid ${field}`);
+    return trimmed;
+}
+
+export function parseStringArray(value: unknown, field: string): string[] {
+    if (!Array.isArray(value)) throw new Error(`Invalid ${field}`);
+    return value.map(v => parseString(v, field));
+}
+
+import type { VisualConfig } from './types';
+
+export function parseVisualConfig(value: unknown): VisualConfig {
+    if (!value || typeof value !== 'object') throw new Error('Invalid visualConfig');
+    const { positions, connections } = value as Record<string, unknown>;
+    if (!positions || typeof positions !== 'object') throw new Error('Invalid visualConfig.positions');
+    if (!Array.isArray(connections)) throw new Error('Invalid visualConfig.connections');
+
+    const parsedPositions: Record<string, { x: number; y: number }> = {};
+    for (const [k, pos] of Object.entries(positions as Record<string, unknown>)) {
+        if (!pos || typeof pos !== 'object') throw new Error('Invalid position');
+        const { x, y } = pos as Record<string, unknown>;
+        if (typeof x !== 'number' || typeof y !== 'number') throw new Error('Invalid position');
+        parsedPositions[k] = { x, y };
+    }
+
+    const parsedConnections = (connections as unknown[]).map((c) => {
+        if (!c || typeof c !== 'object') throw new Error('Invalid connection');
+        const { from, to } = c as Record<string, unknown>;
+        const parsedFrom = parseString(from, 'connection.from');
+        const parsedTo = parseString(to, 'connection.to');
+        return { from: parsedFrom, to: parsedTo };
+    });
+
+    return { positions: parsedPositions, connections: parsedConnections };
+}


### PR DESCRIPTION
## Summary
- validate request bodies in API routes with small helpers
- enforce a basic Content Security Policy
- add E2E test for module activation and connection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687518bbdcf48333a02dbc78bcd042b3