### PR TITLE
Add typed event bus and module settings

### DIFF
--- a/src/core/ModuleLoader.ts
+++ b/src/core/ModuleLoader.ts
@@ -5,18 +5,24 @@ import type { ModuleConfig } from '@/modules/module-types';
 
 // Usamos la interfaz ModuleConfig importada para asegurar consistencia entre módulos.
 
-const ALL_MODULES: ModuleConfig[] = [
+const CORE_MODULES: ModuleConfig[] = [
     inventoryModuleConfig,
     crmModuleConfig,
     logisticsModuleConfig,
 ];
+
+const EXTERNAL_MODULES: ModuleConfig[] = [];
+
+export function registerExternalModule(config: ModuleConfig) {
+    EXTERNAL_MODULES.push(config);
+}
 
 /**
  * Devuelve un array con las configuraciones de todos los módulos registrados.
  * @returns {ModuleConfig[]} Un array de todas las configuraciones de módulos.
  */
 export function getAllModules(): ModuleConfig[] {
-    return ALL_MODULES;
+    return [...CORE_MODULES, ...EXTERNAL_MODULES];
 }
 
 /**
@@ -25,5 +31,5 @@ export function getAllModules(): ModuleConfig[] {
  * @returns {ModuleConfig | undefined} La configuración del módulo o undefined si no se encuentra.
  */
 export function getModuleById(id: string): ModuleConfig | undefined {
-    return ALL_MODULES.find(m => m.id === id);
+    return [...CORE_MODULES, ...EXTERNAL_MODULES].find(m => m.id === id);
 }

--- a/src/core/store/useMainStore.ts
+++ b/src/core/store/useMainStore.ts
@@ -5,21 +5,25 @@ interface MainState {
     isInitialized: boolean;
     activeModules: string[];
     visualConfig: VisualConfig;
+    moduleSettings: Record<string, Record<string, unknown>>;
     setInitialData: (data: Tenant | null) => void;
     updateModulePosition: (moduleId: string, position: ModulePosition) => VisualConfig;
     addConnection: (connection: ModuleConnection) => VisualConfig;
     toggleModule: (moduleId: string) => { activeModules: string[]; visualConfig: VisualConfig };
+    updateSettings: (moduleId: string, settings: Record<string, unknown>) => Record<string, Record<string, unknown>>;
 }
 
 export const useMainStore = create<MainState>((set, get) => ({
     isInitialized: false,
     activeModules: [],
     visualConfig: { positions: {}, connections: [] },
+    moduleSettings: {},
 
     setInitialData: (data) => set({
         // Manejo de data null o undefined
         activeModules: Array.isArray(data?.activeModules) ? data!.activeModules : [],
         visualConfig: data?.visualConfig ?? { positions: {}, connections: [] },
+        moduleSettings: {},
         isInitialized: true,
     }),
 
@@ -41,6 +45,16 @@ export const useMainStore = create<MainState>((set, get) => ({
             set({ visualConfig: newVisualConfig });
         }
         return newVisualConfig;
+    },
+
+    updateSettings: (moduleId, settings) => {
+        const state = get();
+        const newSettings = {
+            ...state.moduleSettings,
+            [moduleId]: { ...state.moduleSettings[moduleId], ...settings },
+        };
+        set({ moduleSettings: newSettings });
+        return newSettings;
     },
 
     toggleModule: (moduleId: string) => {

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -68,3 +68,15 @@ export interface ModuleEvent {
     // CORRECCIÓN: Se usa 'unknown' en lugar de 'any' para un tipado más seguro.
     payload: unknown;
 }
+
+// Mapa de eventos con sus payloads para tipar el ModuleBus
+export interface ModuleEventMap {
+    'module:data:transfer': {
+        from: string;
+        to: string;
+        payload: unknown;
+    };
+    'module:dragged': ModuleDraggedPayload;
+    'module:connect': ModuleConnectPayload;
+    'ui:module:open': { moduleId: string };
+}

--- a/src/modules/crm/config.ts
+++ b/src/modules/crm/config.ts
@@ -8,4 +8,11 @@ export const crmModuleConfig: ModuleConfig = {
     apiBasePath: '/api/modules/crm',
     // CORRECCIÓN: Se elimina el tipo ComponentType que no se usaba.
     UiComponent: dynamic(() => import('./ui')),
+    settingsSchema: {
+        type: 'object',
+        properties: {
+            customFields: { type: 'array', items: { type: 'string' } },
+        },
+    },
+    defaultSettings: { customFields: [] },
 };

--- a/src/modules/inventory/config.ts
+++ b/src/modules/inventory/config.ts
@@ -7,4 +7,11 @@ export const inventoryModuleConfig: ModuleConfig = {
     dependencies: [],
     apiBasePath: '/api/modules/inventory',
     UiComponent: dynamic(() => import('./ui')),
+    settingsSchema: {
+        type: 'object',
+        properties: {
+            itemsPerPage: { type: 'number', default: 20 },
+        },
+    },
+    defaultSettings: { itemsPerPage: 20 },
 };

--- a/src/modules/logistics/config.ts
+++ b/src/modules/logistics/config.ts
@@ -8,4 +8,11 @@ export const logisticsModuleConfig: ModuleConfig = {
     apiBasePath: '/api/modules/logistics',
     // CORRECCIÓN: Se elimina el tipo ComponentType que no se usaba.
     UiComponent: dynamic(() => import('./ui')),
+    settingsSchema: {
+        type: 'object',
+        properties: {
+            defaultCarrier: { type: 'string', default: 'UPS' },
+        },
+    },
+    defaultSettings: { defaultCarrier: 'UPS' },
 };

--- a/src/modules/module-types.ts
+++ b/src/modules/module-types.ts
@@ -6,4 +6,6 @@ export interface ModuleConfig {
     dependencies: string[];
     apiBasePath: string;
     UiComponent: ComponentType<unknown>;
+    settingsSchema?: object;
+    defaultSettings?: Record<string, unknown>;
 }

--- a/tests/integration/ModulesSidebar.test.tsx
+++ b/tests/integration/ModulesSidebar.test.tsx
@@ -17,7 +17,7 @@ describe('ModulesSidebar', () => {
 
         // Estado inicial: solo 'inventory' está activo
         act(() => {
-            useMainStore.setState({ activeModules: ['inventory'] });
+            useMainStore.setState({ activeModules: ['inventory'], moduleSettings: {} });
         });
 
         render(<ModulesSidebar onConfigChange={handleConfigChange} />);

--- a/tests/unit/useMainStore.test.ts
+++ b/tests/unit/useMainStore.test.ts
@@ -9,6 +9,7 @@ describe('useMainStore', () => {
                 isInitialized: false,
                 activeModules: [],
                 visualConfig: { positions: {}, connections: [] },
+                moduleSettings: {},
             });
         });
     });
@@ -32,6 +33,7 @@ describe('useMainStore', () => {
                     positions: { crm: { x: 1, y: 1 }, logistics: { x: 2, y: 2 } },
                     connections: [{ from: 'crm', to: 'logistics' }],
                 },
+                moduleSettings: {},
             });
         });
 


### PR DESCRIPTION
## Summary
- map event names to payload types and type ModuleBus
- support settings in ModuleConfig
- add example settings for core modules
- allow registration of external modules
- store module settings in main store
- update tests for new store shape

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68751cfc84c08333a498e9cabead2fb9