### PR TITLE
Add Stripe checkout and portal endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Esta experiencia inmersiva ofrece una manera intuitiva y dinámica de gestionar 
 - **Autenticación Segura**: gestionada con **NextAuth.js (Auth.js v5)**.
 - **Persistencia de Datos**: Prisma ORM sobre PostgreSQL.
 - **Notificaciones por Email**: envío de correos transaccionales con **Resend** y plantillas en **React Email**.
+- **Pagos y Suscripciones**: integración con **Stripe** (Checkout, Webhooks y Portal del Cliente).
 - **Observabilidad Completa**:
     - Métricas expuestas para **Prometheus** (`/api/metrics`).
     - Logs estructurados.

--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -19,6 +19,12 @@ export default function SettingsPage() {
     });
   };
 
+  const handlePortal = async () => {
+    const res = await fetch('/api/stripe/portal', { method: 'POST' });
+    const data = await res.json();
+    if (data.url) window.location.href = data.url;
+  };
+
   if (loading) return <p>Cargando...</p>;
 
   return (
@@ -26,7 +32,8 @@ export default function SettingsPage() {
       <h1 className="text-2xl mb-4">Ajustes del Tenant</h1>
       <label className="block mb-2">Nombre</label>
       <input value={name} onChange={e => setName(e.target.value)} className="text-black mb-4" />
-      <button onClick={handleSave} className="bg-blue-600 px-4 py-2 rounded">Guardar</button>
+      <button onClick={handleSave} className="bg-blue-600 px-4 py-2 rounded mr-2">Guardar</button>
+      <button onClick={handlePortal} className="bg-secondary px-4 py-2 rounded">Gestionar Suscripción</button>
     </div>
   );
 }

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { getToken } from 'next-auth/jwt';
+import { db } from '@/lib/db';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-04-10' });
+const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET!;
+
+export async function POST(req: NextRequest) {
+  const token = await getToken({ req, secret: NEXTAUTH_SECRET });
+  if (!token?.sub) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+  }
+
+  const { plan } = await req.json().catch(() => ({}));
+  if (typeof plan !== 'string') {
+    return NextResponse.json({ error: 'Plan inválido' }, { status: 400 });
+  }
+
+  const tenant = await db.tenant.findUnique({
+    where: { ownerId: token.sub },
+    include: { subscription: true },
+  });
+  if (!tenant) {
+    return NextResponse.json({ error: 'Tenant no encontrado' }, { status: 404 });
+  }
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    line_items: [{ price: plan, quantity: 1 }],
+    success_url: `${process.env.NEXTAUTH_URL}/dashboard`,
+    cancel_url: `${process.env.NEXTAUTH_URL}/pricing`,
+    customer: tenant.subscription?.customerId,
+    metadata: { tenantId: tenant.id, plan },
+  });
+
+  return NextResponse.json({ url: session.url });
+}

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { getToken } from 'next-auth/jwt';
+import { db } from '@/lib/db';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-04-10' });
+const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET!;
+
+export async function POST(req: NextRequest) {
+  const token = await getToken({ req, secret: NEXTAUTH_SECRET });
+  if (!token?.sub) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+  }
+
+  const tenant = await db.tenant.findUnique({
+    where: { ownerId: token.sub },
+    include: { subscription: true },
+  });
+  if (!tenant?.subscription) {
+    return NextResponse.json({ error: 'Sin suscripción' }, { status: 400 });
+  }
+
+  const session = await stripe.billingPortal.sessions.create({
+    customer: tenant.subscription.customerId,
+    return_url: `${process.env.NEXTAUTH_URL}/dashboard/settings`,
+  });
+
+  return NextResponse.json({ url: session.url });
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+const plans = [
+  { id: 'price_basic', name: 'Básico', price: '$10/mes', desc: 'Funcionalidades esenciales' },
+  { id: 'price_pro', name: 'Pro', price: '$20/mes', desc: 'Para equipos que crecen' },
+  { id: 'price_enterprise', name: 'Empresarial', price: '$50/mes', desc: 'Soporte completo y escalabilidad' },
+];
+
+export default function PricingPage() {
+  const subscribe = async (plan: string) => {
+    const res = await fetch('/api/stripe/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan }),
+    });
+    const data = await res.json();
+    if (data.url) window.location.href = data.url;
+  };
+
+  return (
+    <div className="p-8 text-white">
+      <h1 className="text-3xl text-center mb-6">Elige tu plan</h1>
+      <div className="flex flex-col md:flex-row gap-4 justify-center">
+        {plans.map(p => (
+          <div key={p.id} className="bg-surface p-6 rounded shadow text-center">
+            <h2 className="text-2xl mb-2">{p.name}</h2>
+            <p className="mb-2 font-semibold">{p.price}</p>
+            <p className="mb-4 text-text-secondary">{p.desc}</p>
+            <button onClick={() => subscribe(p.id)} className="bg-primary px-4 py-2 rounded">Suscribirse</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/pricing` page with plan selection and subscribe button
- add API endpoint to create Stripe checkout session
- add API endpoint to create Stripe customer portal session
- link to Stripe portal from dashboard settings
- document Stripe support in feature list

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6875c598d26c8333af51369a02bbe65b