### PR TITLE
Add member management UI and APIs

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/page.tsx
@@ -4,11 +4,21 @@ import { useEffect, useState } from 'react';
 export default function SettingsPage() {
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(true);
+  const [members, setMembers] = useState<any[]>([]);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState('EDITOR');
+
+  const fetchMembers = () => {
+    fetch('/api/tenant/members')
+      .then(res => res.json())
+      .then(setMembers);
+  };
 
   useEffect(() => {
     fetch('/api/tenant/me')
       .then(res => res.json())
       .then(data => { setName(data.name); setLoading(false); });
+    fetchMembers();
   }, []);
 
   const handleSave = async () => {
@@ -25,6 +35,25 @@ export default function SettingsPage() {
     if (data.url) window.location.href = data.url;
   };
 
+  const handleInvite = async () => {
+    await fetch('/api/tenant/invite', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: inviteEmail, role: inviteRole }),
+    });
+    setInviteEmail('');
+    fetchMembers();
+  };
+
+  const handleRemove = async (userId: string) => {
+    await fetch('/api/tenant/members', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId }),
+    });
+    fetchMembers();
+  };
+
   if (loading) return <p>Cargando...</p>;
 
   return (
@@ -34,6 +63,50 @@ export default function SettingsPage() {
       <input value={name} onChange={e => setName(e.target.value)} className="text-black mb-4" />
       <button onClick={handleSave} className="bg-blue-600 px-4 py-2 rounded mr-2">Guardar</button>
       <button onClick={handlePortal} className="bg-secondary px-4 py-2 rounded">Gestionar Suscripción</button>
+
+      <hr className="my-4 border-gray-700" />
+      <h2 className="text-xl mb-2">Invitar usuario</h2>
+      <div className="mb-4 space-x-2">
+        <input
+          type="email"
+          placeholder="email@example.com"
+          value={inviteEmail}
+          onChange={e => setInviteEmail(e.target.value)}
+          className="text-black px-2 py-1"
+        />
+        <select
+          value={inviteRole}
+          onChange={e => setInviteRole(e.target.value)}
+          className="text-black px-2 py-1"
+        >
+          <option value="ADMIN">Admin</option>
+          <option value="EDITOR">Editor</option>
+          <option value="VIEWER">Espectador</option>
+        </select>
+        <button onClick={handleInvite} className="bg-blue-600 px-3 py-1 rounded">Invitar</button>
+      </div>
+
+      <h2 className="text-xl mb-2">Miembros</h2>
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr>
+            <th className="py-1">Email</th>
+            <th className="py-1">Rol</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {members.map(m => (
+            <tr key={m.user.id} className="border-t border-gray-700">
+              <td className="py-1">{m.user.email}</td>
+              <td className="py-1">{m.role}</td>
+              <td className="py-1 text-right">
+                <button onClick={() => handleRemove(m.user.id)} className="text-red-500">Eliminar</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/app/accept-invite/page.tsx
+++ b/src/app/accept-invite/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function AcceptInvitePage() {
+  const [status, setStatus] = useState('Procesando invitación...');
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch('/api/tenant/invite/accept', { method: 'POST' })
+      .then(res => res.ok ? res.json() : Promise.reject())
+      .then(() => {
+        setStatus('Invitación aceptada. Redirigiendo...');
+        setTimeout(() => router.push('/dashboard'), 1500);
+      })
+      .catch(() => setStatus('Error al aceptar la invitación'));
+  }, [router]);
+
+  return <div className="p-4 text-white">{status}</div>;
+}

--- a/src/app/api/tenant/invite/accept/route.ts
+++ b/src/app/api/tenant/invite/accept/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { db } from '@/lib/db';
+
+const SECRET = process.env.NEXTAUTH_SECRET!;
+
+export async function POST(request: NextRequest) {
+  const token = await getToken({ req: request, secret: SECRET });
+  if (!token?.sub) return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+
+  const user = await db.user.findUnique({ where: { id: token.sub } });
+  if (!user?.email) return NextResponse.json({ error: 'Email no encontrado' }, { status: 400 });
+
+  const invitations = await db.invitation.findMany({
+    where: { email: user.email, accepted: false },
+  });
+
+  for (const inv of invitations) {
+    await db.tenantUser.create({ data: { tenantId: inv.tenantId, userId: user.id, role: inv.role } });
+    await db.invitation.update({ where: { id: inv.id }, data: { accepted: true } });
+  }
+
+  return NextResponse.json({ accepted: invitations.length });
+}

--- a/src/app/api/tenant/members/route.ts
+++ b/src/app/api/tenant/members/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { db } from '@/lib/db';
+import { parseString } from '@/lib/validators';
+
+const SECRET = process.env.NEXTAUTH_SECRET!;
+
+export async function GET(request: NextRequest) {
+  const token = await getToken({ req: request, secret: SECRET });
+  if (!token?.sub) return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+
+  const members = await db.tenantUser.findMany({
+    where: { tenant: { ownerId: token.sub } },
+    include: { user: { select: { id: true, name: true, email: true } } },
+  });
+
+  return NextResponse.json(members);
+}
+
+export async function DELETE(request: NextRequest) {
+  const token = await getToken({ req: request, secret: SECRET });
+  if (!token?.sub) return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+
+  const body = await request.json().catch(() => ({}));
+  let userId: string;
+  try {
+    userId = parseString(body.userId, 'userId');
+  } catch {
+    return NextResponse.json({ error: 'Datos inválidos' }, { status: 400 });
+  }
+
+  const tenant = await db.tenant.findUnique({ where: { ownerId: token.sub } });
+  if (!tenant) return NextResponse.json({ error: 'Tenant no encontrado' }, { status: 404 });
+  if (userId === token.sub) return NextResponse.json({ error: 'No puedes eliminarte a ti mismo' }, { status: 400 });
+
+  await db.tenantUser.delete({ where: { tenantId_userId: { tenantId: tenant.id, userId } } });
+  return NextResponse.json({ success: true });
+}

--- a/src/emails/InvitationEmail.tsx
+++ b/src/emails/InvitationEmail.tsx
@@ -11,7 +11,7 @@ export default function InvitationEmail({ tenantName, role }: Props) {
     <BaseLayout>
       <Heading>Invitación a {tenantName}</Heading>
       <Text>Has sido invitado como {role}. Haz clic en el siguiente enlace para aceptar la invitación.</Text>
-      <Link href="{process.env.NEXTAUTH_URL}">Ir a CoreFoundry</Link>
+      <Link href={`${process.env.NEXTAUTH_URL}/accept-invite`}>Aceptar invitación</Link>
     </BaseLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add invitation acceptance link and flow
- expose API to accept invitations
- expose API to list and remove tenant members
- create page for accepting invitations
- extend tenant settings page with invite form and member list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875cba8e06c83338f305c15a3b8ed89