### PR TITLE
Add basic onboarding tour and empty state

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { useMainStore } from '@/core/store/useMainStore';
 import ModuleBus from '@/core/bus/ModuleBus';
 import { ModuleDraggedPayload, ModuleConnectPayload, VisualConfig } from '@/lib/types';
 import { ModulesSidebar } from '@/components/ui/ModulesSidebar';
+import DashboardTour from '@/components/ui/DashboardTour';
 
 // Cargamos Phaser solo en cliente
 const PhaserCanvas = dynamic(() => import('@/components/game/PhaserCanvas'), {
@@ -38,7 +39,8 @@ export default function DashboardPage() {
         setInitialData,
         updateModulePosition,
         addConnection,
-        visualConfig
+        visualConfig,
+        activeModules,
     } = useMainStore();
     const [selectedModuleUi, setSelectedModuleUi] = useState<React.ComponentType | null>(null);
 
@@ -134,10 +136,16 @@ export default function DashboardPage() {
     // 6) Render final
     return (
         <div className="w-screen h-screen bg-background flex">
+            <DashboardTour />
             <ModulesSidebar onConfigChange={handleConfigChange} />
 
             <main className="flex-1 relative">
                 <PhaserCanvas visualConfig={visualConfig} />
+                {activeModules.length === 0 && (
+                    <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                        <p className="text-white text-xl">Activa un módulo para comenzar</p>
+                    </div>
+                )}
             </main>
 
             <div

--- a/src/components/ui/DashboardTour.tsx
+++ b/src/components/ui/DashboardTour.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface Step {
+    title: string;
+    content: string;
+}
+
+const steps: Step[] = [
+    {
+        title: 'Activa Módulos',
+        content: 'Usa la barra lateral para activar los módulos que necesites.',
+    },
+    {
+        title: 'Conecta Módulos',
+        content: 'Mantén Shift y haz clic en dos módulos para conectarlos.',
+    },
+    {
+        title: 'Explora la UI',
+        content: 'Haz clic en un módulo para abrir su panel de control.',
+    },
+];
+
+export const DashboardTour = () => {
+    const [stepIndex, setStepIndex] = useState(0);
+    const [show, setShow] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const visited = localStorage.getItem('hasVisitedDashboard');
+        if (!visited) {
+            setShow(true);
+        }
+    }, []);
+
+    const handleNext = () => {
+        if (stepIndex < steps.length - 1) {
+            setStepIndex(stepIndex + 1);
+        } else {
+            setShow(false);
+            if (typeof window !== 'undefined') {
+                localStorage.setItem('hasVisitedDashboard', 'true');
+            }
+        }
+    };
+
+    if (!show) return null;
+
+    const step = steps[stepIndex];
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+            <div className="bg-surface p-6 rounded-lg text-white max-w-sm text-center space-y-4">
+                <h3 className="text-lg font-bold">{step.title}</h3>
+                <p>{step.content}</p>
+                <button
+                    onClick={handleNext}
+                    className="bg-primary hover:bg-primary/80 px-4 py-2 rounded-md"
+                >
+                    {stepIndex < steps.length - 1 ? 'Siguiente' : 'Finalizar'}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default DashboardTour;


### PR DESCRIPTION
## Summary
- show a simple step-based tour for first-time dashboard users
- display hint overlay when no modules are active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875d049b5448333ab0246e80cf9244e