### PR TITLE
Fix dashboard loading state

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -54,15 +54,20 @@ export default function DashboardPage() {
         if (session && !isInitialized) {
             fetch('/api/tenant/me', {
                 method: 'GET',
-                credentials: 'include',              // ← Importante para enviar la cookie
+                credentials: 'include', // Necesario para enviar la cookie
                 headers: { 'Content-Type': 'application/json' },
             })
-                .then(res => {
+                .then((res) => {
                     if (!res.ok) throw new Error('No autorizado');
                     return res.json();
                 })
-                .then(data => setInitialData(data))
-                .catch(err => console.error('Error al cargar datos del dashboard:', err));
+                .then((data) => setInitialData(data))
+                .catch((err) => {
+                    console.error('Error al cargar datos del dashboard:', err);
+                    // Inicializamos el estado aunque falle la petición para evitar
+                    // quedar atrapados en el modo "Verificando sesión".
+                    setInitialData(null);
+                });
         }
     }, [session, status, isInitialized, setInitialData, router]);
 


### PR DESCRIPTION
## Summary
- avoid getting stuck on the dashboard when `/api/tenant/me` fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875e7945b248333a6537d25b2644bb1