### PR TITLE
Fix TypeScript build issue for swagger-ui-react

### DIFF
--- a/src/types/swagger-ui-react.d.ts
+++ b/src/types/swagger-ui-react.d.ts
@@ -1,0 +1,1 @@
+declare module 'swagger-ui-react';


### PR DESCRIPTION
## Summary
- add a minimal declaration file for `swagger-ui-react` so Next.js build works

## Testing
- `npm run lint`
- `npm run test`
- `npx tsc --noEmit` *(fails: Cannot find name 'jest' and other issues)*
- `npm run build` *(fails: could not fetch font due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68771efc09bc8333ba7779a3ba539423