### PR TITLE
Fix Google sign‑in CSP issue

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,7 +6,7 @@ const nextConfig = {
 
     async headers() {
         const ContentSecurityPolicy =
-            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src https://accounts.google.com; connect-src 'self';";
+            "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src https://accounts.google.com; connect-src 'self';";
         return [
             {
                 source: '/(.*)',


### PR DESCRIPTION
## Summary
- loosen CSP to allow inline scripts

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68785f9f3e2083338952ea6164686660