### PR TITLE
Add dockerignore to slim build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.git
+.github
+.next
+coverage
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.env
+.env.*
+.DS_Store
+


### PR DESCRIPTION
## Summary
- prevent copying local dependencies and tooling into Docker builds by creating `.dockerignore`

## Testing
- `npm test`
- `docker build -t core-foundry:test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68786bd5573083339439692076c30eb1